### PR TITLE
Potential fix for code scanning alert no. 2: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,5 +16,5 @@ def ping():
 
 # This block allows running the app directly using `python app.py`
 if __name__ == '__main__':
-    debug_mode = os.getenv('FLASK_DEBUG', '0') == '1'
+    debug_mode = os.getenv('FLASK_DEBUG', '0').strip().lower() in {'1', 'true', 'yes'}
     app.run(debug=debug_mode, host='0.0.0.0', port=5000)

--- a/app.py
+++ b/app.py
@@ -16,6 +16,5 @@ def ping():
 
 # This block allows running the app directly using `python app.py`
 if __name__ == '__main__':
-    import os
     debug_mode = os.getenv('FLASK_DEBUG', '0') == '1'
     app.run(debug=debug_mode, host='0.0.0.0', port=5000)

--- a/app.py
+++ b/app.py
@@ -16,4 +16,6 @@ def ping():
 
 # This block allows running the app directly using `python app.py`
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', '0') == '1'
+    app.run(debug=debug_mode, host='0.0.0.0', port=5000)


### PR DESCRIPTION
Potential fix for [https://github.com/Coraa-12/simple-flask-api/security/code-scanning/2](https://github.com/Coraa-12/simple-flask-api/security/code-scanning/2)

To fix the issue, we will modify the `app.run()` call to ensure that debug mode is not enabled by default. Instead, we will use an environment variable to control whether debug mode is enabled. This approach ensures that debug mode can be explicitly enabled for development environments while remaining disabled in production.

Specifically:
1. Import the `os` module to access environment variables.
2. Replace the hardcoded `debug=True` with a dynamic value that checks an environment variable (e.g., `FLASK_DEBUG`).
3. Set `debug` to `True` only if the `FLASK_DEBUG` environment variable is set to `'1'`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
